### PR TITLE
fix(readme): correct clarityContent to clarityConsent in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ And _Voilà_!
 
 You can easily check that the script is correctly injected by inspecting your page on your browser. Note that nothing is injected if the key is missing!
 
-You can also use the util `clarityContent` to use a cookie when the user consent to it. It's a wrapper around `window.clarity`. [See Clarity documentation](https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-consent).
+You can also use the util `clarityConsent` to use a cookie when the user consent to it. It's a wrapper around `window.clarity`. [See Clarity documentation](https://learn.microsoft.com/en-us/clarity/setup-and-installation/cookie-consent).
 
 ## Development
 


### PR DESCRIPTION
Hello, 
Just a quick fix for a typo that I spotted in the README; thanks.
- Documentation update:
  * Corrected the utility function name from `clarityContent` to `clarityConsent` in the usage instructions within `README.md`.